### PR TITLE
Update Tilt CI dependencies

### DIFF
--- a/.github/workflows/tilt-ci.yml
+++ b/.github/workflows/tilt-ci.yml
@@ -9,20 +9,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Create k8s cluster
         uses: AbsaOSS/k3d-action@v2.4.0
         with:
-          cluster-name: cva-enduro-workflows-ci
+          cluster-name: cva-enduro-ci
           args: >-
-            --registry-create cva-enduro-workflows-ci-registry
+            --registry-create cva-enduro-ci-registry
             --no-lb
             --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
       - name: Install Tilt
-        uses: yokawasa/action-setup-kube-tools@v0.9.3
+        uses: yokawasa/action-setup-kube-tools@v0.13.1
         with:
           setup-tools: |
             tilt
-          tilt: v0.30.2
+          tilt: v0.35.2
       - name: Check tilt ci
-        run: timeout 600 tilt ci
+        run: tilt ci

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ in a Kubernetes cluster. It has been tested with k3d, Minikube and Kind.
 
 - [Docker] (v18.09+)
 - [kubectl]
-- [Tilt] (v0.22.2+)
+- [Tilt] (v0.35.0+)
 
 A local Kubernetes cluster:
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,5 +1,6 @@
-version_settings(constraint=">=0.22.2")
+version_settings(constraint=">=0.35.0")
 secret_settings(disable_scrub=True)
+ci_settings(timeout="10m", readiness_timeout="10m")
 load("ext://uibutton", "cmd_button", "text_input")
 load('ext://dotenv', 'dotenv')
 


### PR DESCRIPTION
- Bump Tilt version to 0.35.2
- Bump actions/checkout to v6
- Bump yokawasa/action-setup-kube-tools to v0.13.1
- Add `ci_settings()` to Tilt config to adjust timeout limits