### PR TITLE
Bump Go version 1.24.12 -> 1.24.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/artefactual-sdps/cva-enduro-workflows
 
-go 1.24.12
+go 1.24.13
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
Upgrade Go to mitigate https://pkg.go.dev/vuln/GO-2026-4337