### PR TITLE
Update config to synchronize with Enduro

### DIFF
--- a/.github/workflows/tilt-ci.yml
+++ b/.github/workflows/tilt-ci.yml
@@ -14,10 +14,11 @@ jobs:
         uses: AbsaOSS/k3d-action@v2.4.0
         with:
           cluster-name: cva-enduro-ci
+          k3d-version: v5.8.3
           args: >-
             --registry-create cva-enduro-ci-registry
             --no-lb
-            --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
+            --k3s-arg "--disable=traefik,servicelb,metrics-server@server:*"
       - name: Install Tilt
         uses: yokawasa/action-setup-kube-tools@v0.13.1
         with:

--- a/Tiltfile.enduro
+++ b/Tiltfile.enduro
@@ -1,4 +1,4 @@
-version_settings(constraint=">=0.22.2")
+version_settings(constraint=">=0.35.0")
 secret_settings(disable_scrub=True)
 load("ext://uibutton", "cmd_button", "text_input")
 load("ext://dotenv", "dotenv")
@@ -27,6 +27,6 @@ k8s_yaml(kustomize("hack/kube/overlays/enduro"))
 # CVA Enduro resources
 k8s_resource(
   "cva-enduro-worker",
-  labels=["CVA Enduro"],
+  labels=["CVA-Enduro"],
   trigger_mode=trigger_mode
 )

--- a/hack/kube/overlays/dev/secret.yaml
+++ b/hack/kube/overlays/dev/secret.yaml
@@ -8,14 +8,19 @@ stringData:
     debug = true
     verbosity = 2
 
-    [reportsBucket]
-    url = "file:///home/enduro/reports"
+    [ingestBucket]
+    endpoint = "http://minio.enduro-sdps:9000"
+    pathStyle = true
+    accessKey = "minio"
+    secretKey = "minio123"
+    region = "us-west-1"
+    bucket = "enduro-ingest"
 
     [temporal]
     address = "temporal.enduro-sdps:7233"
     namespace = "default"
     taskQueue = "cva-enduro"
-    workflowName = "cva-enduro"
+    workflowName = "batch-csv"
 
     [worker]
     maxConcurrentSessions = 1

--- a/hack/kube/overlays/enduro/secret.yaml
+++ b/hack/kube/overlays/enduro/secret.yaml
@@ -10,11 +10,19 @@ stringData:
 
     sharedPath = "/home/enduro/shared"
 
+    [ingestBucket]
+    endpoint = "http://minio.enduro-sdps:9000"
+    pathStyle = true
+    accessKey = "minio"
+    secretKey = "minio123"
+    region = "us-west-1"
+    bucket = "enduro-ingest"
+
     [temporal]
     address = "temporal.enduro-sdps:7233"
     namespace = "default"
     taskQueue = "cva-enduro"
-    workflowName = "cva-enduro"
+    workflowName = "batch-csv"
 
     [worker]
     maxConcurrentSessions = 1

--- a/internal/activities/create_csv.go
+++ b/internal/activities/create_csv.go
@@ -41,8 +41,11 @@ func (a *CreateCSV) Execute(ctx context.Context, params *CreateCSVParams) (*Crea
 	if len(params.SIPs) == 0 {
 		return nil, fmt.Errorf("create CSV: no SIPs provided")
 	}
+	if params.Batch == nil {
+		return nil, fmt.Errorf("create CSV: missing batch")
+	}
 
-	key := fmt.Sprintf("batch_%s.csv", params.Batch.UUID)
+	key := fmt.Sprintf("reports/batch_%s.csv", params.Batch.UUID)
 
 	bw, err := a.bucket.NewWriter(ctx, key, nil)
 	if err != nil {

--- a/internal/activities/create_csv_test.go
+++ b/internal/activities/create_csv_test.go
@@ -46,7 +46,7 @@ func TestCreateCSV_Execute(t *testing.T) {
 					},
 				},
 			},
-			expectedKey: "batch_33333333-3333-3333-3333-333333333333.csv",
+			expectedKey: "reports/batch_33333333-3333-3333-3333-333333333333.csv",
 			want: `title,alternativeIdentifiers,alternativeIdentifierLabels,radGeneralMaterialDesignation,levelOfDescription,culture,publicationStatus,accessRestriction
 Test SIP 1,11111111-2222-3333-4444-555555555555,AIP UUID,Multiple media,File,en,draft,This file has not been reviewed for potential FOIPPA restrictions. Access is pending review and may be delayed. See archivist for details.
 Test SIP 2,22222222-3333-4444-5555-666666666666,AIP UUID,Multiple media,File,en,draft,This file has not been reviewed for potential FOIPPA restrictions. Access is pending review and may be delayed. See archivist for details.
@@ -86,7 +86,7 @@ Test SIP 2,22222222-3333-4444-5555-666666666666,AIP UUID,Multiple media,File,en,
 					},
 				},
 			},
-			expectedKey: "batch_33333333-3333-3333-3333-333333333333.csv",
+			expectedKey: "reports/batch_33333333-3333-3333-3333-333333333333.csv",
 			want: `title,alternativeIdentifiers,alternativeIdentifierLabels,radGeneralMaterialDesignation,levelOfDescription,culture,publicationStatus,accessRestriction
 `,
 		},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,8 +23,8 @@ type Config struct {
 	// number of messages logged.
 	Verbosity int
 
-	// ReportsBucket contains the reports bucket configuration.
-	ReportsBucket *bucket.Config
+	// IngestBucket configuration.
+	IngestBucket *bucket.Config
 
 	// Temporal configures the Temporal server address and workflow information.
 	Temporal Temporal
@@ -58,8 +58,8 @@ func (c Config) Validate() error {
 	var errs error
 
 	// Verify that the required fields have values.
-	if c.ReportsBucket == nil {
-		errs = errors.Join(errs, errRequired("ReportsBucket"))
+	if c.IngestBucket == nil {
+		errs = errors.Join(errs, errRequired("IngestBucket"))
 	}
 	if c.Temporal.TaskQueue == "" {
 		errs = errors.Join(errs, errRequired("Temporal.TaskQueue"))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13,13 +13,13 @@ import (
 const testConfig = `# Config
 debug = true
 verbosity = 2
-[reportsBucket]
+[ingestBucket]
 endpoint = "http://minio.enduro-sdps:9000"
 pathStyle = true
 accessKey = "minio"
 secretKey = "minio123"
 region = "us-west-1"
-bucket = "reports"
+bucket = "enduro-ingest"
 [temporal]
 address = "host:port"
 namespace = "default"
@@ -51,13 +51,13 @@ func TestConfig(t *testing.T) {
 			wantCfg: config.Config{
 				Debug:     true,
 				Verbosity: 2,
-				ReportsBucket: &bucket.Config{
+				IngestBucket: &bucket.Config{
 					Endpoint:  "http://minio.enduro-sdps:9000",
 					PathStyle: true,
 					AccessKey: "minio",
 					SecretKey: "minio123",
 					Region:    "us-west-1",
-					Bucket:    "reports",
+					Bucket:    "enduro-ingest",
 				},
 				Temporal: config.Temporal{
 					Address:      "host:port",
@@ -75,7 +75,7 @@ func TestConfig(t *testing.T) {
 			configFile: "cva-enduro.toml",
 			wantFound:  true,
 			wantErr: `invalid configuration:
-ReportsBucket: missing required value
+IngestBucket: missing required value
 Temporal.TaskQueue: missing required value
 Temporal.WorkflowName: missing required value`,
 		},
@@ -83,7 +83,7 @@ Temporal.WorkflowName: missing required value`,
 			name:       "Errors when MaxConcurrentSessions is less than 1",
 			configFile: "cva-enduro.toml",
 			toml: `# Config
-[reportsBucket]
+[ingestBucket]
 url = "file:///home/enduro/reports"
 [temporal]
 taskQueue = "cva-enduro"

--- a/internal/workflows/batch_poststorage_test.go
+++ b/internal/workflows/batch_poststorage_test.go
@@ -41,7 +41,7 @@ func TestBatchPoststorage(t *testing.T) {
 func (s *BatchPoststorageTestSuite) SetupWorkflowTest(cfg config.Config) {
 	s.env = s.NewTestWorkflowEnvironment()
 
-	b, err := bucket.NewWithConfig(s.T().Context(), cfg.ReportsBucket)
+	b, err := bucket.NewWithConfig(s.T().Context(), cfg.IngestBucket)
 	s.Require().NoError(err)
 	s.bucket = b
 
@@ -69,7 +69,7 @@ func (s *BatchPoststorageTestSuite) TestHappyPath() {
 	}
 
 	s.SetupWorkflowTest(config.Config{
-		ReportsBucket: &bucket.Config{URL: "mem://"},
+		IngestBucket: &bucket.Config{URL: "mem://"},
 	})
 
 	s.env.OnActivity(


### PR DESCRIPTION
Refs #1

- Return an error from the create CSV activity if the Batch param is nil
- Change `reportsBucket` config name to `ingestBucket`
- Change Temporal `workflowName` to "postbatch" to match Enduro config
- Prepend "reports/" to CSV report key
- Change Tilt "CVA Enduro" label to "CVA-Enduro" because whitespace is
  not allowed in Tilt resource labels