### PR TITLE
Clean up ContainerMetadata.xml files

### DIFF
--- a/cmd/worker/workercmd/cmd.go
+++ b/cmd/worker/workercmd/cmd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/artefactual-sdps/temporal-activities/bagcreate"
+	"github.com/artefactual-sdps/temporal-activities/bucketdelete"
 	"github.com/artefactual-sdps/temporal-activities/bucketupload"
 	"github.com/go-logr/logr"
 	"go.artefactual.dev/tools/bucket"
@@ -122,5 +123,10 @@ func (m *Main) registerPostbatchWorkflow() {
 	m.temporalWorker.RegisterActivityWithOptions(
 		activities.NewCreateCSV(m.ingestBucket).Execute,
 		temporalsdk_activity.RegisterOptions{Name: activities.CreateCSVName},
+	)
+
+	m.temporalWorker.RegisterActivityWithOptions(
+		bucketdelete.New(m.ingestBucket).Execute,
+		temporalsdk_activity.RegisterOptions{Name: bucketdelete.Name},
 	)
 }

--- a/internal/workflows/postbatch.go
+++ b/internal/workflows/postbatch.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/artefactual-sdps/temporal-activities/bucketdelete"
 	temporalsdk_workflow "go.temporal.io/sdk/workflow"
 
 	"github.com/artefactual-sdps/cva-enduro-workflows/internal/activities"
@@ -54,6 +55,22 @@ func (w *Postbatch) Execute(
 	).Get(fsCtx, &csvResult)
 	if err != nil {
 		return nil, fmt.Errorf("create CSV: %w", err)
+	}
+
+	// Delete the ContainerMetadata.xml file for each SIP in the batch.
+	for _, sip := range params.SIPs {
+		key := fmt.Sprintf("%s_ContainerMetadata.xml", sip.UUID)
+		fsCtx := withFilesysOpts(ctx, 1*time.Minute)
+		err = temporalsdk_workflow.ExecuteActivity(
+			fsCtx,
+			bucketdelete.Name,
+			bucketdelete.Params{
+				Key: key,
+			},
+		).Get(fsCtx, nil)
+		if err != nil {
+			return nil, fmt.Errorf("delete %s from ingest bucket: %v", key, err)
+		}
 	}
 
 	result.Outcome = OutcomeSuccess

--- a/internal/workflows/postbatch_test.go
+++ b/internal/workflows/postbatch_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/artefactual-sdps/temporal-activities/bucketdelete"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -50,6 +51,11 @@ func (s *PostbatchTestSuite) SetupWorkflowTest(cfg config.Config) {
 		temporalsdk_activity.RegisterOptions{Name: activities.CreateCSVName},
 	)
 
+	s.env.RegisterActivityWithOptions(
+		bucketdelete.New(s.bucket).Execute,
+		temporalsdk_activity.RegisterOptions{Name: bucketdelete.Name},
+	)
+
 	s.workflow = workflows.NewPostbatch(cfg.Postbatch)
 }
 
@@ -85,6 +91,14 @@ func (s *PostbatchTestSuite) TestHappyPath() {
 		},
 		nil,
 	)
+
+	s.env.OnActivity(
+		bucketdelete.Name,
+		mock.AnythingOfType("*context.timerCtx"),
+		&bucketdelete.Params{
+			Key: fmt.Sprintf("%s_ContainerMetadata.xml", sip.UUID),
+		},
+	).Return(nil, nil)
 
 	s.env.ExecuteWorkflow(s.workflow.Execute, &workflows.PostbatchRequest{
 		Batch: batch,


### PR DESCRIPTION
Delete ContainerMetadata.xml files from the ingest bucket after writing the Batch CSV file in the postbatch workflow.