### PR TITLE
Split up preprocessing and postbatch configs

### DIFF
--- a/cmd/worker/workercmd/cmd.go
+++ b/cmd/worker/workercmd/cmd.go
@@ -98,7 +98,7 @@ func (m *Main) Close() error {
 
 func (m *Main) registerPreprocessingWorkflow() {
 	m.temporalWorker.RegisterWorkflowWithOptions(
-		workflows.NewPreprocessing(m.cfg).Execute,
+		workflows.NewPreprocessing(m.cfg.Preprocessing).Execute,
 		temporalsdk_workflow.RegisterOptions{Name: m.cfg.Preprocessing.WorkflowName},
 	)
 
@@ -115,7 +115,7 @@ func (m *Main) registerPreprocessingWorkflow() {
 
 func (m *Main) registerPostbatchWorkflow() {
 	m.temporalWorker.RegisterWorkflowWithOptions(
-		workflows.NewPostbatch(m.cfg).Execute,
+		workflows.NewPostbatch(m.cfg.Postbatch).Execute,
 		temporalsdk_workflow.RegisterOptions{Name: m.cfg.Postbatch.WorkflowName},
 	)
 

--- a/internal/workflows/postbatch.go
+++ b/internal/workflows/postbatch.go
@@ -13,7 +13,7 @@ import (
 
 type (
 	Postbatch struct {
-		cfg config.Config
+		cfg config.PostbatchConfig
 	}
 	PostbatchRequest struct {
 		Batch *types.Batch
@@ -25,7 +25,7 @@ type (
 	}
 )
 
-func NewPostbatch(cfg config.Config) *Postbatch {
+func NewPostbatch(cfg config.PostbatchConfig) *Postbatch {
 	return &Postbatch{cfg: cfg}
 }
 

--- a/internal/workflows/postbatch_test.go
+++ b/internal/workflows/postbatch_test.go
@@ -50,7 +50,7 @@ func (s *PostbatchTestSuite) SetupWorkflowTest(cfg config.Config) {
 		temporalsdk_activity.RegisterOptions{Name: activities.CreateCSVName},
 	)
 
-	s.workflow = workflows.NewPostbatch(cfg)
+	s.workflow = workflows.NewPostbatch(cfg.Postbatch)
 }
 
 func (s *PostbatchTestSuite) TearDownTest() {

--- a/internal/workflows/preprocessing.go
+++ b/internal/workflows/preprocessing.go
@@ -17,7 +17,7 @@ import (
 
 type (
 	Preprocesssing struct {
-		cfg config.Config
+		cfg config.PreprocessingConfig
 	}
 	PreprocessingRequest struct {
 		RelativePath string
@@ -30,7 +30,7 @@ type (
 	}
 )
 
-func NewPreprocessing(cfg config.Config) *Preprocesssing {
+func NewPreprocessing(cfg config.PreprocessingConfig) *Preprocesssing {
 	return &Preprocesssing{cfg: cfg}
 }
 
@@ -98,7 +98,7 @@ func (w *Preprocesssing) Execute(
 		withFilesysOpts(ctx, 10*time.Minute),
 		bagcreate.Name,
 		&bagcreate.Params{
-			SourcePath: filepath.Join(w.cfg.Preprocessing.SharedPath, params.RelativePath),
+			SourcePath: filepath.Join(w.cfg.SharedPath, params.RelativePath),
 		},
 	).Get(ctx, &createBag)
 	if err != nil {
@@ -126,7 +126,7 @@ func (w *Preprocesssing) uploadContainerMDFile(
 	params *PreprocessingRequest,
 ) error {
 	path := filepath.Join(
-		w.cfg.Preprocessing.SharedPath,
+		w.cfg.SharedPath,
 		params.RelativePath,
 		"metadata",
 		"submissionDocumentation",

--- a/internal/workflows/preprocessing_test.go
+++ b/internal/workflows/preprocessing_test.go
@@ -72,7 +72,7 @@ func (s *PreprocessingTestSuite) SetupWorkflowTest(cfg config.Config) {
 		temporalsdk_activity.RegisterOptions{Name: bagcreate.Name},
 	)
 
-	s.workflow = workflows.NewPreprocessing(cfg)
+	s.workflow = workflows.NewPreprocessing(cfg.Preprocessing)
 }
 
 func (s *PreprocessingTestSuite) TearDownTest() {


### PR DESCRIPTION
Only inject the relevant config values into the preprocessing and postbatch workflows.