### PR TITLE
Bump Go version from 1.26.2 to v1.26.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/artefactual-sdps/cva-enduro-workflows
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
Bump Go version to v1.26.3 to fix a number of security vulnerabilities in v1.26.2.