### PR TITLE
Add batch identifier to the batch CSV filename

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/artefactual-sdps/cva-enduro-workflows
 go 1.26.3
 
 require (
-	github.com/artefactual-sdps/enduro v0.29.0
+	github.com/artefactual-sdps/enduro v0.29.1-0.20260522161952-4f8fafb20d69
 	github.com/artefactual-sdps/temporal-activities v0.0.0-20260406175419-303edb7db3db
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.54
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.54.0/go.mod h1:l9rva3ApbBpEJxSNYnwT9N4CDLrWgtq3u8736C5hyJw=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0 h1:s0WlVbf9qpvkh1c/uDAPElam0WrL7fHRIidgZJ7UqZI=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0/go.mod h1:Mf6O40IAyB9zR/1J8nGDDPirZQQPbYJni8Yisy7NTMc=
-github.com/artefactual-sdps/enduro v0.29.0 h1:0Eciws/lbDpRwITzVDDYBSiGKE5kX3BIz1lI030lDWY=
-github.com/artefactual-sdps/enduro v0.29.0/go.mod h1:im5aNrCN9eL4vsWAETfHzGS3BZ8dE3CysxaptbAadg4=
+github.com/artefactual-sdps/enduro v0.29.1-0.20260522161952-4f8fafb20d69 h1:6x6XX+PZIm7mvt68SOOY/0vY5BDN5BFjdDrygQSiAeQ=
+github.com/artefactual-sdps/enduro v0.29.1-0.20260522161952-4f8fafb20d69/go.mod h1:d/di5fiqzM3PJ+3xXtV6yslDwnxabbeNUMeoN4tfj1E=
 github.com/artefactual-sdps/temporal-activities v0.0.0-20260406175419-303edb7db3db h1:/oTyIMjn5Goo/+OK9LEA4iqpWXomSwxmhovO/+Z2MQw=
 github.com/artefactual-sdps/temporal-activities v0.0.0-20260406175419-303edb7db3db/go.mod h1:6GCIagAHHlLlfI5rr7gr/z2NiSFoIBj7WmVUHMecHO8=
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=

--- a/internal/activities/create_csv.go
+++ b/internal/activities/create_csv.go
@@ -49,7 +49,13 @@ func (a *CreateCSV) Execute(ctx context.Context, params *CreateCSVParams) (*Crea
 		return nil, fmt.Errorf("create CSV: missing batch")
 	}
 
+	// If a batch identifier is not set, use the key "batch_<UUID>.csv".
 	key := fmt.Sprintf("reports/batch_%s.csv", params.Batch.UUID)
+
+	// If a batch identifier is set, use "batch_<identifier>_<UUID>.csv".
+	if params.Batch.Identifier != "" {
+		key = fmt.Sprintf("reports/batch_%s_%s.csv", params.Batch.Identifier, params.Batch.UUID)
+	}
 
 	bw, err := a.bucket.NewWriter(ctx, key, nil)
 	if err != nil {

--- a/internal/activities/create_csv_test.go
+++ b/internal/activities/create_csv_test.go
@@ -230,6 +230,54 @@ func TestCreateCSV_Execute(t *testing.T) {
 				"\n",
 		},
 		{
+			name:      "writes CSV with the batch identifier in the key",
+			bucketCfg: &bucket.Config{URL: "file:///" + t.TempDir()},
+			params: &activities.CreateCSVParams{
+				Batch: &childwf.PostbatchBatch{
+					UUID:       batchID,
+					Identifier: "12345",
+				},
+				SIPs: []*childwf.PostbatchSIP{
+					{
+						UUID:      sipID1,
+						Name:      "Test SIP 1",
+						AIPID:     &aipID1,
+						FileCount: 8,
+					},
+				},
+			},
+			setup: func(t *testing.T, b *blob.Bucket) {
+				t.Helper()
+				seedContainerMetadataXML(t, b, sipID1, sipContainerMetadataXML(containerMDXMLParams{
+					consignment:       "900036",
+					recordNumber:      "01-5000-12/2009-01",
+					titleFreeTextPart: "Test Title 1",
+					homeLocation:      "Finance and Supply Chain Management (FSC)",
+				}))
+			},
+			expectedKey: "reports/batch_12345_33333333-3333-3333-3333-333333333333.csv",
+			want: strings.Join(columns, ",") + "\n" +
+				"1," +
+				"01-5000-12," +
+				"VanDocs transfer: 900036," +
+				"Recordkeeping," +
+				"NULL," +
+				"NULL," +
+				"NULL," +
+				"Finance and Supply Chain Management (FSC)," +
+				"F2009-01," +
+				"11111111-2222-3333-4444-555555555555|01-5000-12/2009-01," +
+				"AIP UUID|VanDocs container record number," +
+				"Test Title 1," +
+				"8 digital documents," +
+				"Multiple media," +
+				"File," +
+				"en," +
+				"draft," +
+				accessConditionsValue +
+				"\n",
+		},
+		{
 			name:      "writes CSV with empty event columns when both events are zero",
 			bucketCfg: &bucket.Config{URL: "file:///" + t.TempDir()},
 			params: &activities.CreateCSVParams{
@@ -272,6 +320,16 @@ func TestCreateCSV_Execute(t *testing.T) {
 				"draft," +
 				accessConditionsValue +
 				"\n",
+		},
+		{
+			name:      "errors when no batch provided",
+			bucketCfg: &bucket.Config{URL: "file:///" + t.TempDir()},
+			params: &activities.CreateCSVParams{
+				SIPs: []*childwf.PostbatchSIP{
+					{Name: "Test SIP 1", AIPID: &aipID1},
+				},
+			},
+			wantErr: "create CSV: missing batch",
 		},
 		{
 			name:      "errors when no SIPs provided",


### PR DESCRIPTION
Include the batch identifier, if one is set, in the name of the batch CSV file (e.g. "batch_<identifier>_<batch_uuid>.csv").