### PR TITLE
Upgrade Go version from v1.26.3 to v1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/artefactual-sdps/cva-enduro-workflows
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/artefactual-sdps/enduro v0.30.0


### PR DESCRIPTION
Update Go to v1.26.4 to address two security vulnerabilities:
- https://pkg.go.dev/vuln/GO-2026-5037
- https://pkg.go.dev/vuln/GO-2026-5039